### PR TITLE
instances-length output

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -12,9 +12,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./
-        id: self-test
+        id: without-instances
+        with:
+          github-token: ${{ secrets.PAT }}
+      - name: Show outputs
+        run: |
+          echo "instances=${{ steps.without-instances.outputs.instances }}"
+          echo "instances-length=${{ steps.without-instances.outputs.instances-length }}"
+      - uses: ./
+        id: with-instances
         with:
           github-token: ${{ secrets.PAT }}
           template-repository: infrastructure-blocks/ts-lib-template
-      - run: |
-          echo ${{ steps.self-test.outputs.instances }}
+      - name: Show outputs
+        run: |
+          echo "instances=${{ steps.with-instances.outputs.instances }}"
+          echo "instances-length=${{ steps.with-instances.outputs.instances-length }}"

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,8 @@ inputs:
 outputs:
   instances:
     description: A JSON array of all the repositories instantiating the provided template.
+  instances-length:
+    description: The number of instances returned.
 runs:
   using: "docker"
   image: Dockerfile

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -24,7 +24,8 @@ export interface Config {
 }
 
 export interface ListTemplateRepositoryInstancesOutputs extends Outputs {
-  ["instances"]: string;
+  instances: string;
+  "instances-length": string;
 }
 
 export class ListTemplateRepositoryInstancesHandler
@@ -45,6 +46,7 @@ export class ListTemplateRepositoryInstancesHandler
     const instances = await this.findTemplateRepositoryInstances();
     return {
       instances: JSON.stringify(instances),
+      "instances-length": JSON.stringify(instances.length),
     };
   }
 


### PR DESCRIPTION
This can be useful to create GitHub Actions conditional
expression based on whether a given amount of instances were
returned or not.
